### PR TITLE
add IFS individual sensor support 

### DIFF
--- a/.shell/zmod_ifs.py
+++ b/.shell/zmod_ifs.py
@@ -107,6 +107,10 @@ class zmod_ifs:
         self.gcode.register_command('IFS_EXTRUDER_SENSOR', self.cmd_IFS_EXTRUDER_SENSOR)
         self.gcode.register_command('IFS_REMOVE_PRUTOK', self.cmd_IFS_REMOVE_PRUTOK)
         self.gcode.register_command('IFS_REMOVE_CURRENT_PRUTOK', self.cmd_IFS_REMOVE_CURRENT_PRUTOK)
+        self.gcode.register_command('IFS_MOTION_ON', self.cmd_IFS_MOTION_ON)
+        self.gcode.register_command('IFS_MOTION_OFF', self.cmd_IFS_MOTION_OFF)
+        self.gcode.register_command('IFS_SWITCH_ON', self.cmd_IFS_SWITCH_ON)                                                                                                 
+        self.gcode.register_command('IFS_SWITCH_OFF', self.cmd_IFS_SWITCH_OFF)
 
         self.gcode.register_command('IFS_F10', self.cmd_IFS_F10)        # Вставить пруток
         self.gcode.register_command('IFS_F11', self.cmd_IFS_F11)        # Извлечь пруток
@@ -235,8 +239,8 @@ class zmod_ifs:
             result = (value >= 0.72)
         return result
 
-    def get_ifs_sensor(self):
-        return self.ifs_data.get_stall()
+    def get_ifs_sensor(self, port):
+        return self.ifs_data.get_stall(port)
 
     def set_cur_port(self, port):
         return self.ifs_data.set_cur_port(port)
@@ -947,6 +951,35 @@ class zmod_ifs:
             self.gcode.run_script_from_command(f"TEMPERATURE_WAIT SENSOR=extruder MINIMUM={config['temp']-2} MAXIMUM={config['temp']+4}")
         self.gcode.run_script_from_command(f"IFS_REMOVE_PRUTOK PRUTOK={prutok} FORCE=0")
 
+    def cmd_IFS_MOTION_ON(self, gcmd):
+        eventtime = self.reactor.monotonic()
+        self._update_filament_runout_pos(eventtime)
+        if self.new:
+            self.runout_helper.note_filament_present(eventtime, True)
+        else:
+            self.runout_helper.note_filament_present(True)
+
+    def cmd_IFS_MOTION_OFF(self, gcmd):
+        if self.new:
+            eventtime = self.reactor.monotonic()
+            self.runout_helper.note_filament_present(eventtime, False)
+        else:
+            self.runout_helper.note_filament_present(False)
+
+    def cmd_IFS_SWITCH_ON(self, gcmd):
+        if self.new:
+            eventtime = self.reactor.monotonic()
+            self.runout_helper.note_filament_present(eventtime, True)
+        else:
+            self.runout_helper.note_filament_present(True)
+
+    def cmd_IFS_SWITCH_OFF(self, gcmd):
+        if self.new:
+            eventtime = self.reactor.monotonic()
+            self.runout_helper.note_filament_present(eventtime, False)
+        else:
+            self.runout_helper.note_filament_present(False)
+
     def _sensor_reader(self):
         while not self.stop_thread:
             ser = None
@@ -1054,6 +1087,7 @@ class IfsData:
         self.Chan = 0           # Текущий активный порт
         self.Insert = 0         # В каком порту появился филамент
         self.Stall = False      # Движение по любому порту
+        self.Stalls = [False, False, False, False]
         self.stall_state = 0    # Движение по любому порту RAW
         self.State = 0          # Состояние IFS
         self.NeedInsert = False # Нужно ли вставлять пруток
@@ -1103,7 +1137,11 @@ class IfsData:
             if self.cur_port == 0:
                 self.Stall = stall_state != 0
             else:
-                self.Stall = (stall_state >> (self.cur_port - 1) ) & 1 == 1
+                self.Stall = (stall_state >> (self.cur_port - 1) ) & 1 == 1           
+            self.Stalls[0] = (stall_state >> 0 ) & 1 == 1
+            self.Stalls[1] = (stall_state >> 1 ) & 1 == 1
+            self.Stalls[2] = (stall_state >> 2 ) & 1 == 1
+            self.Stalls[3] = (stall_state >> 3 ) & 1 == 1
             self.Silk = silk_state
             self.State = state
             self.Chan = chan
@@ -1117,9 +1155,12 @@ class IfsData:
             else:
                 self.cur_port = port
 
-    def get_stall(self):
+    def get_stall(self, port):
         with self.lock:
-            return self.Stall
+            if port == 0:
+                return self.Stall
+            else:
+                return self.Stalls[port-1]
 
     # Возвращает статус конкретного порта
     def get_port(self, port):

--- a/.shell/zmod_ifs_motion_sensor.py
+++ b/.shell/zmod_ifs_motion_sensor.py
@@ -21,6 +21,7 @@ class ZmodIfsMotionSensor:
         # Get printer objects
         self.reactor = self.printer.get_reactor()
         self.runout_helper = filament_switch_sensor.RunoutHelper(config)
+        self.port = config.getint('port', 0, minval=0, maxval=4)
         sig = inspect.signature(self.runout_helper.note_filament_present)
 
         self.zmod_color = self.printer.lookup_object('zmod_color', None)
@@ -48,24 +49,6 @@ class ZmodIfsMotionSensor:
         # Регистрация объекта
         self.printer.add_object(f"filament_motion_sensor {self.name}", self)
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command('IFS_MOTION_ON', self.cmd_IFS_MOTION_ON)
-        self.gcode.register_command('IFS_MOTION_OFF', self.cmd_IFS_MOTION_OFF)
-
-
-    def cmd_IFS_MOTION_ON(self, gcmd):
-        eventtime = self.reactor.monotonic()
-        self._update_filament_runout_pos(eventtime)
-        if self.new:
-            self.runout_helper.note_filament_present(eventtime, True)
-        else:
-            self.runout_helper.note_filament_present(True)
-
-    def cmd_IFS_MOTION_OFF(self, gcmd):
-        if self.new:
-            eventtime = self.reactor.monotonic()
-            self.runout_helper.note_filament_present(eventtime, False)
-        else:
-            self.runout_helper.note_filament_present(False)
 
     def _update_filament_runout_pos(self, eventtime=None):
         if eventtime is None:
@@ -98,7 +81,7 @@ class ZmodIfsMotionSensor:
         return self.extruder.find_past_position(print_time)
     def _extruder_pos_update_event(self, eventtime):
         # Получаем статус филамента из zmod_ifs
-        if self.ifs.get_ifs_sensor():
+        if self.ifs.get_ifs_sensor(self.port):
             self._update_filament_runout_pos(eventtime)
 
             extruder_pos = self._get_extruder_pos(eventtime)

--- a/.shell/zmod_ifs_switch_sensor.py
+++ b/.shell/zmod_ifs_switch_sensor.py
@@ -25,22 +25,6 @@ class ZmodIfsSwitchSensor:
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command('IFS_SWITCH_ON', self.cmd_IFS_SWITCH_ON)
-        self.gcode.register_command('IFS_SWITCH_OFF', self.cmd_IFS_SWITCH_OFF)
-
-    def cmd_IFS_SWITCH_ON(self, gcmd):
-        if self.new:
-            eventtime = self.reactor.monotonic()
-            self.runout_helper.note_filament_present(eventtime, True)
-        else:
-            self.runout_helper.note_filament_present(True)
-
-    def cmd_IFS_SWITCH_OFF(self, gcmd):
-        if self.new:
-            eventtime = self.reactor.monotonic()
-            self.runout_helper.note_filament_present(eventtime, False)
-        else:
-            self.runout_helper.note_filament_present(False)
 
     def _handle_ready(self):
 
@@ -65,5 +49,61 @@ class ZmodIfsSwitchSensor:
         value, _ = self.query_adc.adc["temperature_sensor filamentValue"].get_last_value()
         return value >= 0.72 if value > 0.3 else True
 
+
+# ZmodIfsPortSensor
+
+class ZmodIfsPortSensor:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+
+        self.runout_helper = RunoutHelper(config)
+        self.port = config.getint('port', 0, minval=0, maxval=4)
+        self.get_status = self.runout_helper.get_status
+        self.printer.add_object(f"filament_switch_sensor {self.name}", self)
+
+        self.reactor = self.printer.get_reactor()
+        sig = inspect.signature(self.runout_helper.note_filament_present)
+        self.new = 'eventtime' in sig.parameters
+
+        self.last_state = True
+        self.timer = self.reactor.register_timer(self.check_state, self.reactor.NOW)
+
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        self.gcode = self.printer.lookup_object('gcode')
+
+    def _handle_ready(self):
+        self.ifs = self.printer.lookup_object('zmod_ifs')
+        self.check_state(self.reactor.NOW)
+
+    def check_state(self, eventtime):
+        try:
+            new_state = self.get_filament()
+        except Exception as e:
+            self.gcode.respond_info(f"Error reading filament sensor: {e}")
+            new_state = True
+
+        print_state = self.printer.lookup_object('print_stats').get_status(eventtime)['state']
+        is_printing = print_state in ('printing')
+
+        if not is_printing and hasattr(self, "last_state") and self.last_state and not new_state:
+            self.runout_helper._exec_gcode("", self.runout_helper.runout_gcode)
+        self.last_state = new_state
+
+        sig = inspect.signature(self.runout_helper.note_filament_present)
+        if self.new:
+            self.runout_helper.note_filament_present(eventtime, new_state)
+        else:
+            self.runout_helper.note_filament_present(new_state)
+
+        return eventtime + 0.5
+
+    def get_filament(self):
+        return self.ifs.get_port(self.port)
+
 def load_config_prefix(config):
-    return ZmodIfsSwitchSensor(config)
+    sensor_type = config.get('type', 'switch')
+    if sensor_type == 'port':
+        return ZmodIfsPortSensor(config)
+    else:
+        return ZmodIfsSwitchSensor(config)


### PR DESCRIPTION
and run runout_gcode even when not printing only for zmod_ifs_switch_sensor when type is equal to port

In this way, the presence and motion sensors of the IFS can be defined individually while maintaining the functionality of the definitions of head_switch_sensor and ifs_motion_sensor. For example:

user.cfg:
```
[zmod_ifs_switch_sensor head_switch_sensor]
pause_on_runout: False

[zmod_ifs_motion_sensor ifs_motion_sensor]
pause_on_runout: False

[zmod_ifs_motion_sensor ifs_motion_sensor_1]
pause_on_runout: False
port:1

....

[zmod_ifs_switch_sensor ifs_port_sensor_1]
pause_on_runout: False
type:port
port:1
runout_gcode:
    _RUNOUT_PORT PORT=1
insert_gcode:
    _IFS_INSERT PORT=1

....
```

