### PR TITLE
Request to add lessWaste to official plugin list

### DIFF
--- a/moonraker.conf
+++ b/moonraker.conf
@@ -113,6 +113,14 @@ origin: https://github.com/ghzserg/notify.git
 is_system_service: False
 primary_branch: main
 
+[update_manager lessWaste]
+type: git_repo
+channel: stable
+path: /root/printer_data/config/mod_data/plugins/lessWaste
+origin: https://github.com/Hrybmo/lessWaste.git
+is_system_service: False
+primary_branch: master
+
 [include mod_data/plugins.moonraker.conf]
 
 [include mod_data/user.moonraker.conf]


### PR DESCRIPTION
Hello, I would like to add a plugin to the official channel to share with others. The plugin was forked from bambufy and updated to be specific to Orca slicer and the AD5X. If there is a better way for integration or changes that should be made then please let me know. I feel that lessWaste is at a good point. Thanks for ZMOD!