### PR TITLE
Update zmod_color.py - option to perform full color change process even when target filament is the same

### DIFF
--- a/.shell/zmod_color.py
+++ b/.shell/zmod_color.py
@@ -474,6 +474,8 @@ class zmod_color:
         self.gcode.register_command('IN_ZCOLOR', self.cmd_IN_ZCOLOR)
         self.gcode.register_command('UPDATE_FF_OFFSET', self.cmd_UPDATE_FF_OFFSET)
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        
+        self.reactor = self.printer.get_reactor()
 
         with open(FFCONFIG, 'r') as file:
             data = json.load(file)
@@ -989,7 +991,16 @@ class zmod_color:
             spool_number = mapping[channel]
             current_spool_number = self.get_current_channel()
 
-            if spool_number != current_spool_number or not self.get_extruder_sensor():
+            full_color_change = True
+            if self.get_extruder_sensor() and spool_number == current_spool_number:
+                print_state = self.printer.lookup_object('print_stats').get_status(self.reactor.monotonic())['state']
+                is_printing = print_state == 'printing'
+                save_variables = self.printer.lookup_object('save_variables', None)
+                save_variables = {} if save_variables == None else save_variables.allVariables
+                if save_variables.get('always_full_color_change', 0) == 0 or not is_printing:  # I think this can be called while not printing. Let's not mess with that.
+                    full_color_change = False
+        
+            if full_color_change:
                 self.gcode.run_script_from_command(f"INSERT_PRUTOK_IFS PRUTOK={spool_number} NEED_STOP=0 TRASH=0")
             else:
                 gcmd.respond_raw(f"Current Prutok = Prutok = {spool_number}")

--- a/.shell/zmod_color.py
+++ b/.shell/zmod_color.py
@@ -993,11 +993,9 @@ class zmod_color:
 
             full_color_change = True
             if self.get_extruder_sensor() and spool_number == current_spool_number:
-                print_state = self.printer.lookup_object('print_stats').get_status(self.reactor.monotonic())['state']
-                is_printing = print_state == 'printing'
                 save_variables = self.printer.lookup_object('save_variables', None)
                 save_variables = {} if save_variables == None else save_variables.allVariables
-                if save_variables.get('always_full_color_change', 0) == 0 or not is_printing:  # I think this can be called while not printing. Let's not mess with that.
+                if save_variables.get('always_full_color_change', 0) == 0:
                     full_color_change = False
         
             if full_color_change:

--- a/.shell/zmod_color.py
+++ b/.shell/zmod_color.py
@@ -474,8 +474,6 @@ class zmod_color:
         self.gcode.register_command('IN_ZCOLOR', self.cmd_IN_ZCOLOR)
         self.gcode.register_command('UPDATE_FF_OFFSET', self.cmd_UPDATE_FF_OFFSET)
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
-        
-        self.reactor = self.printer.get_reactor()
 
         with open(FFCONFIG, 'r') as file:
             data = json.load(file)


### PR DESCRIPTION
Currently, if for example, T0 and T1 are both set to channel 1, and a T1 command is encountered while T0 is loaded, zMod skips most of the color change process.

This pull request adds an option to override this, and perform the full withdraw and reinsert even if both T commands are mapped to the same channel. This option is not turned on by default, but can be enabled with:

`SAVE_VARIABLES VARIABLE=always_full_color_change VALUE=1`

This may be useful if the user intends to do a manual swap (I know, ideally they'll use a different channel, but let's offer the option), or for testing purposes. It may also be useful if they have some kind of addon or replacement for the IFS.